### PR TITLE
feat: Docker infrastructure + student workspace

### DIFF
--- a/.docker/Dockerfile.node
+++ b/.docker/Dockerfile.node
@@ -1,0 +1,65 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV container=docker
+
+# Install systemd + SSH + Ansible prerequisites
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    systemd \
+    systemd-sysv \
+    openssh-server \
+    python3 \
+    python3-apt \
+    sudo \
+    iproute2 \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# Mask unnecessary systemd units that cause issues in containers
+RUN systemctl mask \
+    dev-hugepages.mount \
+    sys-fs-fuse-connections.mount \
+    systemd-udev-trigger.service \
+    systemd-udevd.service \
+    systemd-update-utmp.service \
+    systemd-logind.service \
+    getty@.service \
+    getty.target
+
+# Enable SSH via systemd
+RUN systemctl enable ssh
+
+# === THE SSH ROOT FAIRY'S HANDIWORK ===
+# The SSH Root Fairy has visited every node in the fleet.
+# Root login: ENABLED. Password auth: ENABLED. LoginGraceTime: UNSET (default 120s).
+# These are the misconfigurations the cadet must fix.
+RUN mkdir -p /run/sshd \
+    && sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config \
+    && sed -i 's/#PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+# The Root Fairy leaves a calling card
+RUN echo '# The SSH Root Fairy was here. Root login for everyone!' \
+    > /etc/ssh/sshd_config.d/root-fairy.conf \
+    && echo '# "Why lock doors when you can leave them wide open?" — The SSH Root Fairy' \
+    >> /etc/ssh/sshd_config.d/root-fairy.conf
+
+# Create cadet user for SSH access
+RUN useradd -m -s /bin/bash cadet \
+    && echo 'cadet:academy' | chpasswd \
+    && echo 'cadet ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/cadet \
+    && chmod 0440 /etc/sudoers.d/cadet
+
+# Set up SSH key auth for cadet
+RUN mkdir -p /home/cadet/.ssh \
+    && chmod 700 /home/cadet/.ssh \
+    && chown cadet:cadet /home/cadet/.ssh
+
+# Set root password (insecure — deliberate misconfiguration for training)
+RUN echo 'root:starfall' | chpasswd
+
+EXPOSE 22
+
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["/sbin/init"]

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,70 @@
+services:
+  sdc-web:
+    build:
+      context: .
+      dockerfile: Dockerfile.node
+    container_name: sdc-web
+    hostname: sdc-web
+    privileged: true
+    cgroup: host
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ./ssh-keys/authorized_keys:/home/cadet/.ssh/authorized_keys:ro
+    networks:
+      fleet_net:
+        ipv4_address: 172.30.0.11
+    ports:
+      - "2221:22"
+
+  sdc-db:
+    build:
+      context: .
+      dockerfile: Dockerfile.node
+    container_name: sdc-db
+    hostname: sdc-db
+    privileged: true
+    cgroup: host
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ./ssh-keys/authorized_keys:/home/cadet/.ssh/authorized_keys:ro
+    networks:
+      fleet_net:
+        ipv4_address: 172.30.0.12
+    ports:
+      - "2222:22"
+
+  sdc-comms:
+    build:
+      context: .
+      dockerfile: Dockerfile.node
+    container_name: sdc-comms
+    hostname: sdc-comms
+    privileged: true
+    cgroup: host
+    tmpfs:
+      - /run
+      - /run/lock
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ./ssh-keys/authorized_keys:/home/cadet/.ssh/authorized_keys:ro
+    networks:
+      fleet_net:
+        ipv4_address: 172.30.0.13
+    ports:
+      - "2223:22"
+
+networks:
+  fleet_net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+*.retry
+*.pyc
+__pycache__/
+.molecule/
+.cache/
+*.log
+.DS_Store
+.pytest_cache/
+.docker/ssh-keys/
+workspace/.ssh/
+venv/
+
+# Internal dev files
+CLAUDE.md
+AGENTS.md
+IMPLEMENTATION_PLAN.md
+ideas.md
+fixes.md
+PLAN.md
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# Command Center
+.cc-config.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+SHELL := /bin/bash
+ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+.PHONY: setup test reset destroy ssh-web ssh-db ssh-comms help
+
+help: ## Show available commands
+	@echo ""
+	@echo "=============================================="
+	@echo "  STARFALL DEFENCE CORPS ACADEMY"
+	@echo "  Mission 1.2: Lock the Door"
+	@echo "=============================================="
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+
+setup: ## Start the fleet (3 target nodes)
+	@bash $(ROOT_DIR)/scripts/setup-lab.sh
+
+test: ## Ask ARIA to verify your work
+	@bash $(ROOT_DIR)/scripts/check-work.sh
+
+reset: ## Destroy and rebuild all fleet nodes
+	@bash $(ROOT_DIR)/scripts/reset-lab.sh
+
+destroy: ## Tear down everything (containers, keys, venv)
+	@bash $(ROOT_DIR)/scripts/destroy-lab.sh
+
+ssh-web: ## SSH into sdc-web (fleet web server)
+	@ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null cadet@localhost -p 2221
+
+ssh-db: ## SSH into sdc-db (fleet database server)
+	@ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null cadet@localhost -p 2222
+
+ssh-comms: ## SSH into sdc-comms (fleet comms relay)
+	@ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null cadet@localhost -p 2223

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+testinfra
+pyyaml
+molecule

--- a/scripts/destroy-lab.sh
+++ b/scripts/destroy-lab.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+DOCKER_DIR="$ROOT_DIR/.docker"
+
+echo ""
+echo "=============================================="
+echo "  STARFALL DEFENCE CORPS ACADEMY"
+echo "  Destroying Fleet..."
+echo "=============================================="
+echo ""
+
+echo "  Stopping containers..."
+docker compose -f "$DOCKER_DIR/docker-compose.yml" down -v 2>&1 | while read -r line; do
+    echo "    $line"
+done
+
+echo "  Removing SSH keys..."
+rm -rf "$DOCKER_DIR/ssh-keys"
+rm -rf "$ROOT_DIR/workspace/.ssh"
+
+echo "  Removing Python environment..."
+rm -rf "$ROOT_DIR/venv"
+
+echo ""
+echo "  Fleet destroyed. Run 'make setup' to rebuild."
+echo ""

--- a/scripts/reset-lab.sh
+++ b/scripts/reset-lab.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+DOCKER_DIR="$ROOT_DIR/.docker"
+
+echo ""
+echo "=============================================="
+echo "  STARFALL DEFENCE CORPS ACADEMY"
+echo "  Resetting Fleet Nodes..."
+echo "=============================================="
+echo ""
+
+echo "  Destroying existing fleet..."
+docker compose -f "$DOCKER_DIR/docker-compose.yml" down -v 2>&1 | while read -r line; do
+    echo "    $line"
+done
+
+echo ""
+echo "  Rebuilding fleet..."
+# Reuse setup script for the rebuild
+bash "$SCRIPT_DIR/setup-lab.sh"

--- a/scripts/setup-lab.sh
+++ b/scripts/setup-lab.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+DOCKER_DIR="$ROOT_DIR/.docker"
+SSH_DIR="$DOCKER_DIR/ssh-keys"
+
+echo ""
+echo "=============================================="
+echo "  STARFALL DEFENCE CORPS ACADEMY"
+echo "  Initialising Fleet Nodes..."
+echo "=============================================="
+echo ""
+
+# Check python3-venv is available
+if ! python3 -m venv --help &>/dev/null; then
+    echo "  ERROR: python3-venv is not installed."
+    echo "  On Debian/Ubuntu: sudo apt install python3-venv"
+    echo "  On Fedora/RHEL:   sudo dnf install python3-virtualenv"
+    exit 1
+fi
+
+# Set up Python virtual environment if not present
+if [ ! -d "$ROOT_DIR/venv" ]; then
+    echo "  Setting up Python environment..."
+    python3 -m venv "$ROOT_DIR/venv"
+    "$ROOT_DIR/venv/bin/pip" install -q -r "$ROOT_DIR/requirements.txt"
+    echo "  Python environment ready."
+    echo ""
+fi
+
+# Generate SSH key pair if not already present
+if [ ! -f "$SSH_DIR/cadet_key" ]; then
+    echo "  Generating SSH credentials..."
+    mkdir -p "$SSH_DIR"
+    ssh-keygen -t ed25519 -f "$SSH_DIR/cadet_key" -N "" -C "cadet@starfall-academy" -q
+    cp "$SSH_DIR/cadet_key.pub" "$SSH_DIR/authorized_keys"
+    chmod 600 "$SSH_DIR/cadet_key"
+    chmod 644 "$SSH_DIR/authorized_keys"
+    echo "  SSH credentials generated."
+    echo ""
+fi
+
+# Copy private key to workspace for Ansible to use
+mkdir -p "$ROOT_DIR/workspace/.ssh"
+cp "$SSH_DIR/cadet_key" "$ROOT_DIR/workspace/.ssh/cadet_key"
+chmod 600 "$ROOT_DIR/workspace/.ssh/cadet_key"
+
+# Build and start containers
+echo "  Building fleet node images..."
+docker compose -f "$DOCKER_DIR/docker-compose.yml" up -d --build 2>&1 | while read -r line; do
+    echo "    $line"
+done
+
+echo ""
+echo "  Waiting for SSH to become available..."
+for node in sdc-web:2221 sdc-db:2222 sdc-comms:2223; do
+    name="${node%%:*}"
+    port="${node##*:}"
+    for i in $(seq 1 30); do
+        if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=1 \
+            -i "$SSH_DIR/cadet_key" cadet@localhost -p "$port" exit 2>/dev/null; then
+            echo "    $name (port $port): ONLINE"
+            break
+        fi
+        if [ "$i" -eq 30 ]; then
+            echo "    $name (port $port): TIMEOUT — check 'docker compose logs $name'"
+        fi
+        sleep 1
+    done
+done
+
+echo ""
+echo "=============================================="
+echo "  Fleet Status: 3 nodes ONLINE"
+echo ""
+echo "  WARNING: The SSH Root Fairy has been here."
+echo "  Root login and password auth are ENABLED."
+echo ""
+echo "  Your workspace: workspace/"
+echo "  Start here:     docs/BRIEFING.md"
+echo "  Verify work:    make test"
+echo "=============================================="
+echo ""

--- a/workspace/ansible.cfg
+++ b/workspace/ansible.cfg
@@ -1,0 +1,17 @@
+[defaults]
+inventory = inventory/hosts.yml
+host_key_checking = False
+remote_user = cadet
+private_key_file = .ssh/cadet_key
+deprecation_warnings = False
+interpreter_python = auto_silent
+
+[privilege_escalation]
+become = True
+become_method = sudo
+become_user = root
+become_ask_pass = False
+
+[ssh_connection]
+pipelining = True
+ssh_args = -o UserKnownHostsFile=/dev/null

--- a/workspace/inventory/hosts.yml
+++ b/workspace/inventory/hosts.yml
@@ -1,0 +1,28 @@
+---
+# Fleet Inventory — Starfall Defence Corps
+# Pre-configured from Mission 1.1 Fleet Census.
+# All 3 fleet nodes are registered and reachable.
+
+all:
+  children:
+    web_servers:
+      hosts:
+        sdc-web:
+          ansible_host: localhost
+          ansible_port: 2221
+          ansible_user: cadet
+          ansible_ssh_private_key_file: .ssh/cadet_key
+    db_servers:
+      hosts:
+        sdc-db:
+          ansible_host: localhost
+          ansible_port: 2222
+          ansible_user: cadet
+          ansible_ssh_private_key_file: .ssh/cadet_key
+    comms_relays:
+      hosts:
+        sdc-comms:
+          ansible_host: localhost
+          ansible_port: 2223
+          ansible_user: cadet
+          ansible_ssh_private_key_file: .ssh/cadet_key

--- a/workspace/playbook.yml
+++ b/workspace/playbook.yml
@@ -1,0 +1,67 @@
+---
+# =============================================================
+# OPERATION: LOCK THE DOOR — SSH Hardening Playbook
+# =============================================================
+#
+# The SSH Root Fairy has visited every node in the fleet.
+# Root login is enabled. Password authentication is on.
+# LoginGraceTime is at its insecure default.
+#
+# Your mission: Complete each task below to lock down SSH.
+# Replace the TODO comments with working Ansible tasks.
+#
+# Run your playbook:  ansible-playbook playbook.yml
+# Dry run first:      ansible-playbook playbook.yml --check --diff
+# Verify your work:   make test  (from project root)
+# =============================================================
+
+- name: Lock the Door — SSH Hardening
+  hosts: all
+  become: true
+
+  tasks: []
+    # ----------------------------------------------------------
+    # Task 1: Disable root login
+    # ----------------------------------------------------------
+    # Module: ansible.builtin.lineinfile
+    # Target: /etc/ssh/sshd_config
+    # What to do: Ensure the line "PermitRootLogin no" is present.
+    #   Use a regexp to match any existing PermitRootLogin line.
+    #   The handler "Restart SSH" should be notified on change.
+    #
+    # Hint: ansible-doc lineinfile
+    #
+    # TODO: Write your task here
+
+    # ----------------------------------------------------------
+    # Task 2: Disable password authentication
+    # ----------------------------------------------------------
+    # Module: ansible.builtin.lineinfile
+    # Target: /etc/ssh/sshd_config
+    # What to do: Ensure "PasswordAuthentication no" is present.
+    #   Use a regexp to match any existing PasswordAuthentication line.
+    #   Notify the handler on change.
+    #
+    # TODO: Write your task here
+
+    # ----------------------------------------------------------
+    # Task 3: Set LoginGraceTime
+    # ----------------------------------------------------------
+    # Module: ansible.builtin.lineinfile
+    # Target: /etc/ssh/sshd_config
+    # What to do: Ensure "LoginGraceTime 30" is present.
+    #   Use a regexp to match any existing LoginGraceTime line.
+    #   Notify the handler on change.
+    #
+    # TODO: Write your task here
+
+  handlers: []
+    # ----------------------------------------------------------
+    # Handler: Restart SSH
+    # ----------------------------------------------------------
+    # Module: ansible.builtin.service
+    # What to do: Restart the ssh service when notified.
+    #   name: ssh
+    #   state: restarted
+    #
+    # TODO: Write your handler here


### PR DESCRIPTION
## Summary
- Docker lab with 3 fleet nodes (SSH Root Fairy misconfigs as starting state)
- Setup/reset/destroy scripts adapted from Mission 1.1
- Pre-filled inventory (spaced repetition from 1.1)
- Skeleton playbook with TODO markers for student completion
- Makefile with all standard targets

Closes #1
Closes #2

## Test plan
- [ ] `make setup` starts 3 containers
- [ ] SSH accessible on ports 2221-2223
- [ ] Root login enabled (verify: `ssh root@localhost -p 2221`)
- [ ] Skeleton playbook passes syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)