### PR TITLE
fix: add missing Molecule tests and check-work.sh

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,32 @@
+dependency:
+  name: galaxy
+
+driver:
+  name: default
+
+platforms:
+  - name: sdc-web
+    managed: false
+    groups:
+      - fleet
+      - web_servers
+  - name: sdc-db
+    managed: false
+    groups:
+      - fleet
+      - db_servers
+  - name: sdc-comms
+    managed: false
+    groups:
+      - fleet
+      - comms_relays
+
+provisioner:
+  name: ansible
+  inventory:
+    links:
+      hosts: inventory/hosts.yml
+
+verifier:
+  name: testinfra
+  directory: tests/

--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -1,0 +1,165 @@
+"""
+ARIA Custom Test Reporter
+Provides color-coded, phase-grouped output for mission verification.
+
+Writes all output to stderr so check-work.sh can discard pytest's
+default stdout while preserving our formatted display.
+"""
+import pytest
+import sys
+
+# -- ANSI escape codes ------------------------------------------------------
+
+_COLOR = hasattr(sys.stderr, "isatty") and sys.stderr.isatty()
+
+
+def _c(code):
+    return code if _COLOR else ""
+
+
+GREEN = _c("\033[32m")
+RED = _c("\033[31m")
+YELLOW = _c("\033[33m")
+CYAN = _c("\033[36m")
+DIM = _c("\033[2m")
+BOLD = _c("\033[1m")
+RESET = _c("\033[0m")
+
+# -- Phase and test name mappings -------------------------------------------
+
+PHASES = {
+    "TestPlaybookStructure": ("1", "OPORD Structure"),
+    "TestDryRun":            ("2", "Dry Run"),
+    "TestSSHHardening":      ("3", "SSH Lockdown"),
+    "TestIdempotency":       ("4", "Idempotency"),
+}
+
+FRIENDLY = {
+    "test_playbook_exists":             "Playbook file exists",
+    "test_playbook_is_valid_yaml":      "Playbook is valid YAML",
+    "test_playbook_has_tasks":          "Playbook contains tasks",
+    "test_playbook_has_handler":        "Playbook contains SSH restart handler",
+    "test_check_mode_succeeds":         "Dry run (--check) succeeds",
+    "test_root_login_disabled":         "Root login disabled on all nodes",
+    "test_password_auth_disabled":      "Password auth disabled on all nodes",
+    "test_login_grace_time_set":        "LoginGraceTime set on all nodes",
+    "test_playbook_is_idempotent":      "Playbook is idempotent (changed=0)",
+}
+
+# -- Reporter ---------------------------------------------------------------
+
+
+class _ARIAReporter:
+    def __init__(self):
+        self._current_class = None
+        self.passed = 0
+        self.failed = 0
+        self.skipped = 0
+        self._phase_results = {}
+        self._current_phase_passed = True
+
+    @staticmethod
+    def _out(text):
+        sys.stderr.write(text)
+        sys.stderr.flush()
+
+    def record(self, nodeid, outcome, longrepr):
+        parts = nodeid.split("::")
+        cls = parts[1] if len(parts) > 1 else ""
+        test = parts[-1]
+
+        num, label = PHASES.get(cls, ("?", "Unknown"))
+        name = FRIENDLY.get(test, test)
+
+        if cls != self._current_class:
+            if self._current_class is not None:
+                self._phase_results[self._current_class] = self._current_phase_passed
+            self._current_phase_passed = True
+            self._current_class = cls
+            self._out(f"\n  {CYAN}{BOLD}Phase {num}: {label}{RESET}\n")
+
+        if outcome != "passed":
+            self._current_phase_passed = False
+
+        if outcome == "passed":
+            self.passed += 1
+            self._out(f"    {GREEN}✓{RESET} {name}\n")
+        elif outcome == "skipped":
+            self.skipped += 1
+            self._out(f"    {YELLOW}○{RESET} {DIM}{name} — skipped{RESET}\n")
+        else:
+            self.failed += 1
+            self._out(f"    {RED}✗{RESET} {name}\n")
+            hint = _extract_hint(longrepr)
+            if hint:
+                self._out(f"      {DIM}↳ {hint}{RESET}\n")
+
+    def summary(self):
+        if self._current_class is not None:
+            self._phase_results[self._current_class] = self._current_phase_passed
+
+        total = self.passed + self.failed + self.skipped
+        self._out(f"\n  {'─' * 44}\n")
+
+        phases_complete = sum(1 for v in self._phase_results.values() if v)
+        total_phases = len(PHASES)
+        self._out(f"  {BOLD}Progress:{RESET} {phases_complete} of {total_phases} phases complete\n")
+
+        parts = []
+        if self.passed:
+            parts.append(f"{GREEN}{self.passed} verified{RESET}")
+        if self.failed:
+            parts.append(f"{RED}{self.failed} deficient{RESET}")
+        if self.skipped:
+            parts.append(f"{YELLOW}{self.skipped} skipped{RESET}")
+        self._out(
+            f"  {BOLD}Results:{RESET} {' · '.join(parts)}"
+            f"  {DIM}({total} checks){RESET}\n"
+        )
+
+
+def _extract_hint(longrepr):
+    """Pull the ARIA: message from an assertion failure."""
+    if longrepr is None:
+        return None
+    crash = getattr(longrepr, "reprcrash", None)
+    if crash:
+        msg = getattr(crash, "message", "")
+        if "ARIA:" in msg:
+            return msg.split("ARIA:", 1)[-1].strip()
+    text = str(longrepr)
+    if "ARIA:" in text:
+        raw = text.split("ARIA:")[-1].splitlines()[0].strip()
+        return raw.rstrip("'\"")
+    return None
+
+
+# -- Singleton instance -----------------------------------------------------
+
+_reporter = _ARIAReporter()
+
+# -- Pytest hooks -----------------------------------------------------------
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_logreport(report):
+    """Intercept results before the default reporter sees them."""
+    if report.when == "call":
+        _reporter.record(report.nodeid, report.outcome, report.longrepr)
+        report.longrepr = None
+    elif report.when == "setup" and report.skipped:
+        _reporter.record(report.nodeid, "skipped", report.longrepr)
+        report.longrepr = None
+
+
+def pytest_report_teststatus(report, config):
+    """Return empty strings so the default reporter prints nothing per-test."""
+    if report.when == "call":
+        return report.outcome, "", ""
+    if report.when == "setup" and report.skipped:
+        return "skipped", "", ""
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Print our summary; clear stats to suppress the default summary."""
+    _reporter.summary()

--- a/molecule/default/tests/test_lock_the_door.py
+++ b/molecule/default/tests/test_lock_the_door.py
@@ -1,0 +1,246 @@
+"""
+=== STARFALL DEFENCE CORPS ACADEMY ===
+ARIA Automated Verification - Mission 1.2: Lock the Door
+========================================================
+"""
+import os
+import re
+import subprocess
+import yaml
+import pytest
+
+
+def _root_dir():
+    """Return the mission root directory."""
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.abspath(os.path.join(tests_dir, "..", "..", ".."))
+
+
+def _workspace_dir():
+    return os.path.join(_root_dir(), "workspace")
+
+
+def _playbook_path():
+    return os.path.join(_workspace_dir(), "playbook.yml")
+
+
+def _load_playbook():
+    path = _playbook_path()
+    if not os.path.isfile(path):
+        return None
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _run_ansible(*args, **kwargs):
+    """Run an ansible command from the workspace directory."""
+    timeout = kwargs.pop("timeout", 60)
+    result = subprocess.run(
+        list(args),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=_workspace_dir(),
+    )
+    return result
+
+
+# -------------------------------------------------------------------
+# Phase 1: Playbook structure
+# -------------------------------------------------------------------
+
+class TestPlaybookStructure:
+    """ARIA verifies: Has the cadet written a valid OPORD?"""
+
+    def test_playbook_exists(self):
+        """Playbook file must exist at workspace/playbook.yml"""
+        assert os.path.isfile(_playbook_path()), (
+            "ARIA: No playbook detected at workspace/playbook.yml. "
+            "Cadet, an operation without an OPORD is chaos. "
+            "Create your playbook and try again."
+        )
+
+    def test_playbook_is_valid_yaml(self):
+        """Playbook must be valid YAML"""
+        path = _playbook_path()
+        if not os.path.isfile(path):
+            pytest.skip("Playbook does not exist yet")
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data is not None, (
+            "ARIA: Playbook is empty. A blank OPORD protects no one."
+        )
+
+    def test_playbook_has_tasks(self):
+        """Playbook must contain actual tasks (not just TODO comments)"""
+        data = _load_playbook()
+        if data is None:
+            pytest.skip("Playbook does not exist yet")
+        assert isinstance(data, list) and len(data) > 0, (
+            "ARIA: Playbook structure is invalid. "
+            "Expected a list of plays."
+        )
+        play = data[0]
+        tasks = play.get("tasks", [])
+        real_tasks = [t for t in tasks if t]
+        assert len(real_tasks) >= 3, (
+            f"ARIA: Insufficient tasks in playbook. Found {len(real_tasks)} "
+            f"task(s) — expected at least 3 (root login, password auth, "
+            f"LoginGraceTime). Complete the TODO sections in your playbook."
+        )
+
+    def test_playbook_has_handler(self):
+        """Playbook must contain an SSH restart handler"""
+        data = _load_playbook()
+        if data is None:
+            pytest.skip("Playbook does not exist yet")
+        play = data[0]
+        handlers = play.get("handlers", [])
+        real_handlers = [h for h in handlers if h]
+        assert len(real_handlers) >= 1, (
+            "ARIA: No handlers found in playbook. "
+            "SSH configuration changes require a service restart. "
+            "Add a handler that restarts the ssh service."
+        )
+        for h in real_handlers:
+            service = h.get("ansible.builtin.service", h.get("service", {}))
+            if isinstance(service, dict):
+                svc_name = service.get("name", "")
+                if svc_name in ("ssh", "sshd"):
+                    return
+        for h in real_handlers:
+            if "ssh" in h.get("name", "").lower():
+                return
+        assert False, (
+            "ARIA: Handler found but it does not appear to manage the SSH service. "
+            "Ensure your handler restarts the 'ssh' service."
+        )
+
+
+# -------------------------------------------------------------------
+# Phase 2: Dry run
+# -------------------------------------------------------------------
+
+class TestDryRun:
+    """ARIA verifies: Does the playbook pass a dry run?"""
+
+    def test_check_mode_succeeds(self):
+        """ansible-playbook --check must succeed"""
+        data = _load_playbook()
+        if data is None:
+            pytest.skip("Playbook does not exist yet")
+        play = data[0]
+        tasks = [t for t in play.get("tasks", []) if t]
+        if len(tasks) < 3:
+            pytest.skip("Playbook tasks not yet complete")
+
+        result = _run_ansible(
+            "ansible-playbook", "playbook.yml", "--check", "--diff",
+        )
+        assert result.returncode == 0, (
+            f"ARIA: Dry run failed. Your playbook has errors that must be "
+            f"resolved before deployment.\n"
+            f"Output: {result.stdout}\n"
+            f"Errors: {result.stderr}\n"
+            f"Run 'ansible-playbook playbook.yml --check --diff' to debug."
+        )
+
+
+# -------------------------------------------------------------------
+# Phase 3: SSH hardening applied
+# -------------------------------------------------------------------
+
+class TestSSHHardening:
+    """ARIA verifies: Has the cadet locked down SSH?"""
+
+    @pytest.fixture(autouse=True)
+    def _require_playbook_run(self):
+        """Skip if playbook hasn't been applied yet."""
+        data = _load_playbook()
+        if data is None:
+            pytest.skip("Playbook does not exist yet")
+        play = data[0]
+        tasks = [t for t in play.get("tasks", []) if t]
+        if len(tasks) < 3:
+            pytest.skip("Playbook tasks not yet complete")
+
+    def _check_sshd_config(self, pattern, directive_name):
+        """Check that a directive is set correctly on all nodes."""
+        result = _run_ansible(
+            "ansible", "all", "-m", "shell",
+            "-a", f"grep -E '^{pattern}' /etc/ssh/sshd_config",
+        )
+        for host in ["sdc-web", "sdc-db", "sdc-comms"]:
+            assert host in result.stdout, (
+                f"ARIA: No response from {host}. "
+                f"Ensure containers are running and connectivity is verified."
+            )
+        assert result.returncode == 0, (
+            f"ARIA: {directive_name} not correctly set on all nodes. "
+            f"Run your playbook and check /etc/ssh/sshd_config.\n"
+            f"Output: {result.stdout}"
+        )
+
+    def test_root_login_disabled(self):
+        """PermitRootLogin must be set to 'no' on all nodes"""
+        self._check_sshd_config(
+            r"PermitRootLogin\s+no",
+            "PermitRootLogin no",
+        )
+
+    def test_password_auth_disabled(self):
+        """PasswordAuthentication must be set to 'no' on all nodes"""
+        self._check_sshd_config(
+            r"PasswordAuthentication\s+no",
+            "PasswordAuthentication no",
+        )
+
+    def test_login_grace_time_set(self):
+        """LoginGraceTime must be set to 30 on all nodes"""
+        self._check_sshd_config(
+            r"LoginGraceTime\s+30",
+            "LoginGraceTime 30",
+        )
+
+
+# -------------------------------------------------------------------
+# Phase 4: Idempotency
+# -------------------------------------------------------------------
+
+class TestIdempotency:
+    """ARIA verifies: Is the playbook idempotent?"""
+
+    def test_playbook_is_idempotent(self):
+        """Running the playbook a second time must show changed=0"""
+        data = _load_playbook()
+        if data is None:
+            pytest.skip("Playbook does not exist yet")
+        play = data[0]
+        tasks = [t for t in play.get("tasks", []) if t]
+        if len(tasks) < 3:
+            pytest.skip("Playbook tasks not yet complete")
+
+        first_run = _run_ansible(
+            "ansible-playbook", "playbook.yml",
+        )
+        if first_run.returncode != 0:
+            pytest.skip(
+                "Playbook failed on first run — fix errors before testing idempotency"
+            )
+
+        second_run = _run_ansible(
+            "ansible-playbook", "playbook.yml",
+        )
+        assert second_run.returncode == 0, (
+            f"ARIA: Playbook failed on second run.\n"
+            f"Output: {second_run.stdout}\n"
+            f"Errors: {second_run.stderr}"
+        )
+        changed_match = re.findall(r"changed=(\d+)", second_run.stdout)
+        total_changed = sum(int(c) for c in changed_match)
+        assert total_changed == 0, (
+            f"ARIA: Idempotency failure. Second playbook run changed "
+            f"{total_changed} task(s). A well-written playbook should make "
+            f"no changes when run against an already-configured system. "
+            f"Check your lineinfile regexp and line parameters."
+        )

--- a/scripts/check-work.sh
+++ b/scripts/check-work.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+TEST_FILE="$ROOT_DIR/molecule/default/tests/test_lock_the_door.py"
+
+# -- Colors ----------------------------------------------------------------
+GREEN='\033[32m'
+RED='\033[31m'
+CYAN='\033[36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+echo ""
+echo -e "  ${CYAN}${BOLD}=============================================="
+echo -e "  ARIA — Automated Review & Intelligence Analyst"
+echo -e "  Mission 1.2: Lock the Door"
+echo -e "  ==============================================${RESET}"
+
+cd "$ROOT_DIR"
+
+# Activate project venv if it exists
+if [ -f "$ROOT_DIR/venv/bin/activate" ]; then
+    source "$ROOT_DIR/venv/bin/activate"
+fi
+
+# Run tests.
+# conftest.py writes our pretty output to stderr.
+# Redirect: stderr→terminal, stdout (pytest default noise)→/dev/null.
+python3 -m pytest "$TEST_FILE" --tb=short -q 2>&1 1>/dev/null
+EXIT_CODE=$?
+
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    echo -e "  ${GREEN}${BOLD}=============================================="
+    echo -e "  ARIA: All objectives verified."
+    echo -e "  Mission 1.2 status: COMPLETE"
+    echo -e ""
+    echo -e "  Cadet, the SSH Root Fairy has been defeated."
+    echo -e "  Fleet SSH access is now hardened."
+    echo -e "  The Starfall Defence Corps salutes your work."
+    echo -e "  ==============================================${RESET}"
+else
+    echo -e "  ${RED}${BOLD}=============================================="
+    echo -e "  ARIA: Deficiencies detected."
+    echo -e "  Review the findings above and correct."
+    echo -e "  Run 'make test' again when ready."
+    echo -e "  ==============================================${RESET}"
+fi
+
+echo ""
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
Test files were lost during squash merge of PR #8. This adds:
- `molecule/default/molecule.yml` — Molecule config
- `molecule/default/tests/test_lock_the_door.py` — 4-phase test suite
- `molecule/default/tests/conftest.py` — ARIA reporter
- `scripts/check-work.sh` — Test runner script

## Test plan
- [ ] `make test` works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)