### PR TITLE
fix: improve skeleton playbook and test output

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -89,10 +89,14 @@ class _ARIAReporter:
             self._out(f"    {YELLOW}○{RESET} {DIM}{name} — skipped{RESET}\n")
         else:
             self.failed += 1
-            self._out(f"    {RED}✗{RESET} {name}\n")
             hint = _extract_hint(longrepr)
             if hint:
+                # Deficiency: expected failure, student hasn't done this yet
+                self._out(f"    {YELLOW}✗{RESET} {name}\n")
                 self._out(f"      {DIM}↳ {hint}{RESET}\n")
+            else:
+                # Error: unexpected failure (syntax error, connection issue)
+                self._out(f"    {RED}✗{RESET} {name}\n")
 
     def summary(self):
         if self._current_class is not None:

--- a/molecule/default/tests/test_lock_the_door.py
+++ b/molecule/default/tests/test_lock_the_door.py
@@ -138,11 +138,8 @@ class TestDryRun:
             "ansible-playbook", "playbook.yml", "--check", "--diff",
         )
         assert result.returncode == 0, (
-            f"ARIA: Dry run failed. Your playbook has errors that must be "
-            f"resolved before deployment.\n"
-            f"Output: {result.stdout}\n"
-            f"Errors: {result.stderr}\n"
-            f"Run 'ansible-playbook playbook.yml --check --diff' to debug."
+            "ARIA: Dry run failed. Your playbook has syntax or logic errors. "
+            "Run 'ansible-playbook playbook.yml --check --diff' to see details."
         )
 
 
@@ -170,15 +167,18 @@ class TestSSHHardening:
             "ansible", "all", "-m", "shell",
             "-a", f"grep -E '^{pattern}' /etc/ssh/sshd_config",
         )
+        # Identify which nodes failed
+        failed_nodes = []
         for host in ["sdc-web", "sdc-db", "sdc-comms"]:
-            assert host in result.stdout, (
-                f"ARIA: No response from {host}. "
-                f"Ensure containers are running and connectivity is verified."
-            )
+            if host not in result.stdout:
+                failed_nodes.append(host)
+            elif f"{host} | FAILED" in result.stdout:
+                failed_nodes.append(host)
         assert result.returncode == 0, (
-            f"ARIA: {directive_name} not correctly set on all nodes. "
-            f"Run your playbook and check /etc/ssh/sshd_config.\n"
-            f"Output: {result.stdout}"
+            f"ARIA: '{directive_name}' not found on: "
+            f"{', '.join(failed_nodes) if failed_nodes else 'all nodes'}. "
+            f"Run your playbook, then verify with: "
+            f"ansible all -m shell -a \"grep {directive_name.split()[0]} /etc/ssh/sshd_config\""
         )
 
     def test_root_login_disabled(self):
@@ -232,9 +232,8 @@ class TestIdempotency:
             "ansible-playbook", "playbook.yml",
         )
         assert second_run.returncode == 0, (
-            f"ARIA: Playbook failed on second run.\n"
-            f"Output: {second_run.stdout}\n"
-            f"Errors: {second_run.stderr}"
+            "ARIA: Playbook failed on second run. "
+            "Fix the errors reported by 'ansible-playbook playbook.yml'."
         )
         changed_match = re.findall(r"changed=(\d+)", second_run.stdout)
         total_changed = sum(int(c) for c in changed_match)

--- a/workspace/playbook.yml
+++ b/workspace/playbook.yml
@@ -8,7 +8,7 @@
 # LoginGraceTime is at its insecure default.
 #
 # Your mission: Complete each task below to lock down SSH.
-# Replace the TODO comments with working Ansible tasks.
+# Replace the TODO markers with the correct Ansible syntax.
 #
 # Run your playbook:  ansible-playbook playbook.yml
 # Dry run first:      ansible-playbook playbook.yml --check --diff
@@ -19,49 +19,47 @@
   hosts: all
   become: true
 
-  tasks: []
+  tasks:
     # ----------------------------------------------------------
     # Task 1: Disable root login
     # ----------------------------------------------------------
-    # Module: ansible.builtin.lineinfile
-    # Target: /etc/ssh/sshd_config
-    # What to do: Ensure the line "PermitRootLogin no" is present.
-    #   Use a regexp to match any existing PermitRootLogin line.
-    #   The handler "Restart SSH" should be notified on change.
+    # Use lineinfile to ensure "PermitRootLogin no" is present
+    # in /etc/ssh/sshd_config. The regexp should match any
+    # existing PermitRootLogin line (commented or not).
     #
     # Hint: ansible-doc lineinfile
-    #
-    # TODO: Write your task here
+    - name: Disable root login
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: "^#?PermitRootLogin"
+        line: "PermitRootLogin no"
+      # TODO: Add 'notify: Restart SSH' to trigger the handler
 
     # ----------------------------------------------------------
     # Task 2: Disable password authentication
     # ----------------------------------------------------------
-    # Module: ansible.builtin.lineinfile
-    # Target: /etc/ssh/sshd_config
-    # What to do: Ensure "PasswordAuthentication no" is present.
-    #   Use a regexp to match any existing PasswordAuthentication line.
-    #   Notify the handler on change.
+    # Same pattern as Task 1, but for PasswordAuthentication.
     #
-    # TODO: Write your task here
+    # TODO: Write this task (use Task 1 as a template)
 
     # ----------------------------------------------------------
     # Task 3: Set LoginGraceTime
     # ----------------------------------------------------------
-    # Module: ansible.builtin.lineinfile
-    # Target: /etc/ssh/sshd_config
-    # What to do: Ensure "LoginGraceTime 30" is present.
-    #   Use a regexp to match any existing LoginGraceTime line.
-    #   Notify the handler on change.
+    # Ensure "LoginGraceTime 30" is present.
+    # The regexp should match any existing LoginGraceTime line.
     #
-    # TODO: Write your task here
+    # TODO: Write this task
 
-  handlers: []
+  handlers:
     # ----------------------------------------------------------
     # Handler: Restart SSH
     # ----------------------------------------------------------
-    # Module: ansible.builtin.service
-    # What to do: Restart the ssh service when notified.
-    #   name: ssh
-    #   state: restarted
+    # This handler restarts the SSH service when notified.
+    # It only runs if a task reports "changed".
     #
-    # TODO: Write your handler here
+    # Module: ansible.builtin.service
+    # name: ssh
+    # state: restarted
+    #
+    # TODO: Write the handler, then add 'notify: Restart SSH'
+    #       to each task above.


### PR DESCRIPTION
## Summary
From E2E testing feedback:

- **Skeleton playbook**: Removed `tasks: []` / `handlers: []` which caused runtime errors. Task 1 now shown as a working example, Tasks 2-3 remain as TODOs.
- **Test output**: Removed raw ansible output dumps from error messages. ARIA hints are now concise and actionable.
- **Color coding**: Deficiencies (expected, student hasn't done this yet) show in yellow. Errors (unexpected, something is broken) show in red.

## Test plan
- [ ] `make test` with skeleton shows yellow deficiencies, not red errors
- [ ] Error messages are concise (no raw ansible output)
- [ ] Skeleton playbook runs without YAML errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)