### PR TITLE
fix: add sshd config validation and SSH service check

### DIFF
--- a/docs/HINTS.md
+++ b/docs/HINTS.md
@@ -52,8 +52,11 @@ This example sets `MaxAuthTries 3` in the SSH config. It is NOT one of your miss
         regexp: '^#?MaxAuthTries'
         line: 'MaxAuthTries 3'
         state: present
+        validate: 'sshd -t -f %s'
       notify: Restart SSH
 ```
+
+The `validate` line is important: it runs `sshd -t` (test mode) on the modified file **before** applying it. If you have a typo, the task will fail safely instead of breaking SSH.
 
 **Understanding `regexp: '^#?MaxAuthTries'`:**
 
@@ -300,6 +303,7 @@ All three containers (`sdc-web`, `sdc-db`, `sdc-comms`) should appear with a sta
         regexp: '^#?PermitRootLogin'
         line: 'PermitRootLogin no'
         state: present
+        validate: 'sshd -t -f %s'
       notify: Restart SSH
 
     - name: Disable password authentication
@@ -308,6 +312,7 @@ All three containers (`sdc-web`, `sdc-db`, `sdc-comms`) should appear with a sta
         regexp: '^#?PasswordAuthentication'
         line: 'PasswordAuthentication no'
         state: present
+        validate: 'sshd -t -f %s'
       notify: Restart SSH
 
     - name: Set LoginGraceTime to 30 seconds
@@ -316,6 +321,7 @@ All three containers (`sdc-web`, `sdc-db`, `sdc-comms`) should appear with a sta
         regexp: '^#?LoginGraceTime'
         line: 'LoginGraceTime 30'
         state: present
+        validate: 'sshd -t -f %s'
       notify: Restart SSH
 
   handlers:

--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -40,6 +40,7 @@ FRIENDLY = {
     "test_playbook_has_tasks":          "Playbook contains tasks",
     "test_playbook_has_handler":        "Playbook contains SSH restart handler",
     "test_check_mode_succeeds":         "Dry run (--check) succeeds",
+    "test_ssh_service_running":         "SSH service running on all nodes",
     "test_root_login_disabled":         "Root login disabled on all nodes",
     "test_password_auth_disabled":      "Password auth disabled on all nodes",
     "test_login_grace_time_set":        "LoginGraceTime set on all nodes",

--- a/molecule/default/tests/test_lock_the_door.py
+++ b/molecule/default/tests/test_lock_the_door.py
@@ -181,6 +181,24 @@ class TestSSHHardening:
             f"ansible all -m shell -a \"grep {directive_name.split()[0]} /etc/ssh/sshd_config\""
         )
 
+    def test_ssh_service_running(self):
+        """SSH service must still be running on all nodes after playbook"""
+        result = _run_ansible(
+            "ansible", "all", "-m", "shell",
+            "-a", "systemctl is-active ssh",
+        )
+        failed_nodes = [
+            host for host in ["sdc-web", "sdc-db", "sdc-comms"]
+            if f"{host} | FAILED" in result.stdout
+            or (host in result.stdout and "inactive" in result.stdout.split(host)[1].split("\n")[0])
+        ]
+        assert result.returncode == 0, (
+            f"ARIA: SSH service is DOWN on: "
+            f"{', '.join(failed_nodes) if failed_nodes else 'one or more nodes'}. "
+            f"A config typo may have broken sshd. Run 'make reset' to restore, "
+            f"then add validate: 'sshd -t -f %s' to your lineinfile tasks."
+        )
+
     def test_root_login_disabled(self):
         """PermitRootLogin must be set to 'no' on all nodes"""
         self._check_sshd_config(

--- a/workspace/playbook.yml
+++ b/workspace/playbook.yml
@@ -33,12 +33,15 @@
         path: /etc/ssh/sshd_config
         regexp: "^#?PermitRootLogin"
         line: "PermitRootLogin no"
+        validate: "sshd -t -f %s"
       # TODO: Add 'notify: Restart SSH' to trigger the handler
 
     # ----------------------------------------------------------
     # Task 2: Disable password authentication
     # ----------------------------------------------------------
     # Same pattern as Task 1, but for PasswordAuthentication.
+    # Keep the 'validate' line — it checks sshd_config syntax
+    # before applying, so a typo won't break SSH.
     #
     # TODO: Write this task (use Task 1 as a template)
 
@@ -47,6 +50,7 @@
     # ----------------------------------------------------------
     # Ensure "LoginGraceTime 30" is present.
     # The regexp should match any existing LoginGraceTime line.
+    # Include validate to protect against typos.
     #
     # TODO: Write this task
 


### PR DESCRIPTION
## Summary
- Skeleton Task 1 now includes `validate: 'sshd -t -f %s'` so students learn safe config editing from the start
- All lineinfile examples in HINTS.md include validate
- Spoiler solution includes validate on all tasks
- New test `test_ssh_service_running` in Phase 3 checks SSH is still up after playbook runs — if a typo kills sshd, student gets clear guidance to `make reset` and add validate

## Test plan
- [ ] SSH service check passes when SSH is running
- [ ] SSH service check gives clear error with recovery instructions if sshd is down
- [ ] validate prevents bad config from being applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)