### PR TITLE
fix: suppress pytest traceback in ARIA output

### DIFF
--- a/scripts/check-work.sh
+++ b/scripts/check-work.sh
@@ -29,7 +29,7 @@ fi
 # Run tests.
 # conftest.py writes our pretty output to stderr.
 # Redirect: stderr→terminal, stdout (pytest default noise)→/dev/null.
-python3 -m pytest "$TEST_FILE" --tb=short -q 2>&1 1>/dev/null
+python3 -m pytest "$TEST_FILE" --tb=no --no-header -q 2>&1 1>/dev/null
 EXIT_CODE=$?
 
 echo ""


### PR DESCRIPTION
## Summary
Change `--tb=short` to `--tb=no --no-header` in check-work.sh.

The `assert 2 == 0 + where 2 = CompletedProcess(...)` lines were pytest's assertion introspection leaking through despite conftest setting `report.longrepr = None`. The `--tb=short` flag still emits these. `--tb=no` fully suppresses them.

## Before
```
    ✗ Root login disabled on all nodes
      ↳ 'PermitRootLogin no' not found on: sdc-web, sdc-db, sdc-comms...
assert 2 == 0
 +  where 2 = CompletedProcess(args=['ansible', 'all', '-m', 'shell'...
```

## After
```
    ✗ Root login disabled on all nodes
      ↳ 'PermitRootLogin no' not found on: sdc-web, sdc-db, sdc-comms...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)