### PR TITLE
fix: suppress pytest noise and prevent test from applying playbook

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -168,3 +168,6 @@ def pytest_report_teststatus(report, config):
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """Print our summary; clear stats to suppress the default summary."""
     _reporter.summary()
+    # Clear default stats so pytest doesn't print its own summary lines
+    terminalreporter.stats.pop("failed", None)
+    terminalreporter.stats.pop("error", None)

--- a/molecule/default/tests/test_lock_the_door.py
+++ b/molecule/default/tests/test_lock_the_door.py
@@ -229,7 +229,7 @@ class TestIdempotency:
     """ARIA verifies: Is the playbook idempotent?"""
 
     def test_playbook_is_idempotent(self):
-        """Running the playbook a second time must show changed=0"""
+        """Running the playbook must show changed=0 (configs already applied)"""
         data = _load_playbook()
         if data is None:
             pytest.skip("Playbook does not exist yet")
@@ -238,25 +238,28 @@ class TestIdempotency:
         if len(tasks) < 3:
             pytest.skip("Playbook tasks not yet complete")
 
-        first_run = _run_ansible(
-            "ansible-playbook", "playbook.yml",
+        # Check if SSH hardening is already applied — skip if not.
+        # This prevents make test from applying the playbook for the student.
+        check = _run_ansible(
+            "ansible", "all", "-m", "shell",
+            "-a", "grep -E '^PermitRootLogin\\s+no' /etc/ssh/sshd_config",
         )
-        if first_run.returncode != 0:
+        if check.returncode != 0:
             pytest.skip(
-                "Playbook failed on first run — fix errors before testing idempotency"
+                "SSH hardening not yet applied — run your playbook first"
             )
 
-        second_run = _run_ansible(
+        result = _run_ansible(
             "ansible-playbook", "playbook.yml",
         )
-        assert second_run.returncode == 0, (
-            "ARIA: Playbook failed on second run. "
+        assert result.returncode == 0, (
+            "ARIA: Playbook failed. "
             "Fix the errors reported by 'ansible-playbook playbook.yml'."
         )
-        changed_match = re.findall(r"changed=(\d+)", second_run.stdout)
+        changed_match = re.findall(r"changed=(\d+)", result.stdout)
         total_changed = sum(int(c) for c in changed_match)
         assert total_changed == 0, (
-            f"ARIA: Idempotency failure. Second playbook run changed "
+            f"ARIA: Idempotency failure. Playbook changed "
             f"{total_changed} task(s). A well-written playbook should make "
             f"no changes when run against an already-configured system. "
             f"Check your lineinfile regexp and line parameters."


### PR DESCRIPTION
## Summary
Two bugs from E2E testing:

1. **pytest assertion lines still showing**: `assert 2 == 0 + where ...` lines leaked despite `--tb=no` because pytest's `-q` summary wasn't being cleared. Fix: clear `failed`/`error` stats in `pytest_terminal_summary`.

2. **`make test` applies the playbook for the student**: The idempotency test ran `ansible-playbook` twice, meaning a second `make test` passed without the student ever running their playbook. Fix: idempotency test now checks if SSH hardening is already applied (greps sshd_config) and skips if not.

## Test plan
- [ ] `make test` output shows NO `assert` lines
- [ ] Running `make test` twice without applying playbook does NOT pass Phase 3
- [ ] After student applies playbook, `make test` passes all phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)