### PR TITLE
fix: clean ARIA output and fix None handlers crash

### DIFF
--- a/molecule/default/tests/test_lock_the_door.py
+++ b/molecule/default/tests/test_lock_the_door.py
@@ -81,7 +81,7 @@ class TestPlaybookStructure:
             "Expected a list of plays."
         )
         play = data[0]
-        tasks = play.get("tasks", [])
+        tasks = play.get("tasks") or []
         real_tasks = [t for t in tasks if t]
         assert len(real_tasks) >= 3, (
             f"ARIA: Insufficient tasks in playbook. Found {len(real_tasks)} "
@@ -95,7 +95,7 @@ class TestPlaybookStructure:
         if data is None:
             pytest.skip("Playbook does not exist yet")
         play = data[0]
-        handlers = play.get("handlers", [])
+        handlers = play.get("handlers") or []
         real_handlers = [h for h in handlers if h]
         assert len(real_handlers) >= 1, (
             "ARIA: No handlers found in playbook. "
@@ -130,7 +130,7 @@ class TestDryRun:
         if data is None:
             pytest.skip("Playbook does not exist yet")
         play = data[0]
-        tasks = [t for t in play.get("tasks", []) if t]
+        tasks = [t for t in play.get("tasks") or [] if t]
         if len(tasks) < 3:
             pytest.skip("Playbook tasks not yet complete")
 
@@ -157,7 +157,7 @@ class TestSSHHardening:
         if data is None:
             pytest.skip("Playbook does not exist yet")
         play = data[0]
-        tasks = [t for t in play.get("tasks", []) if t]
+        tasks = [t for t in play.get("tasks") or [] if t]
         if len(tasks) < 3:
             pytest.skip("Playbook tasks not yet complete")
 
@@ -234,7 +234,7 @@ class TestIdempotency:
         if data is None:
             pytest.skip("Playbook does not exist yet")
         play = data[0]
-        tasks = [t for t in play.get("tasks", []) if t]
+        tasks = [t for t in play.get("tasks") or [] if t]
         if len(tasks) < 3:
             pytest.skip("Playbook tasks not yet complete")
 

--- a/scripts/check-work.sh
+++ b/scripts/check-work.sh
@@ -27,10 +27,12 @@ if [ -f "$ROOT_DIR/venv/bin/activate" ]; then
 fi
 
 # Run tests.
-# conftest.py writes our pretty output to stderr.
-# Redirect: stderr→terminal, stdout (pytest default noise)→/dev/null.
-python3 -m pytest "$TEST_FILE" --tb=no --no-header -q 2>&1 1>/dev/null
-EXIT_CODE=$?
+# conftest.py writes ARIA output to stderr. pytest also leaks assertion
+# noise to stderr. Filter: keep only our ARIA output (indented with 2+ spaces)
+# and strip pytest's "assert ..." and " +  where ..." lines.
+python3 -m pytest "$TEST_FILE" --tb=no --no-header -q 2>&1 1>/dev/null \
+    | grep -vE '^(assert |FAILED| *\+  where|  *\+  |[0-9]+ (passed|failed))' || true
+EXIT_CODE=${PIPESTATUS[0]}
 
 echo ""
 if [ $EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Filter pytest assertion noise (`assert X == Y`, `+ where ...`) from stderr via grep
- Fix TypeError when `handlers:` section has only YAML comments (parses as `None`, not `[]`)
- Same defensive fix for `tasks:` sections
- All deficiency markers now correctly show yellow with ARIA hints

## Test plan
- [ ] `make test` output has NO `assert` or `+ where` lines
- [ ] Skeleton playbook with empty handlers shows yellow hint, not red error
- [ ] All passing tests still show green

🤖 Generated with [Claude Code](https://claude.com/claude-code)