### PR TITLE
fix: force ARIA color output when piped through grep

### DIFF
--- a/molecule/default/tests/conftest.py
+++ b/molecule/default/tests/conftest.py
@@ -5,12 +5,16 @@ Provides color-coded, phase-grouped output for mission verification.
 Writes all output to stderr so check-work.sh can discard pytest's
 default stdout while preserving our formatted display.
 """
+import os
 import pytest
 import sys
 
 # -- ANSI escape codes ------------------------------------------------------
 
-_COLOR = hasattr(sys.stderr, "isatty") and sys.stderr.isatty()
+_COLOR = (
+    os.environ.get("ARIA_COLOR") == "1"
+    or (hasattr(sys.stderr, "isatty") and sys.stderr.isatty())
+)
 
 
 def _c(code):

--- a/scripts/check-work.sh
+++ b/scripts/check-work.sh
@@ -27,10 +27,10 @@ if [ -f "$ROOT_DIR/venv/bin/activate" ]; then
 fi
 
 # Run tests.
+# ARIA_COLOR=1 forces color output even when piped through grep.
 # conftest.py writes ARIA output to stderr. pytest also leaks assertion
-# noise to stderr. Filter: keep only our ARIA output (indented with 2+ spaces)
-# and strip pytest's "assert ..." and " +  where ..." lines.
-python3 -m pytest "$TEST_FILE" --tb=no --no-header -q 2>&1 1>/dev/null \
+# noise to stderr — filter it out, keep only our indented ARIA lines.
+ARIA_COLOR=1 python3 -m pytest "$TEST_FILE" --tb=no --no-header -q 2>&1 1>/dev/null \
     | grep -vE '^(assert |FAILED| *\+  where|  *\+  |[0-9]+ (passed|failed))' || true
 EXIT_CODE=${PIPESTATUS[0]}
 


### PR DESCRIPTION
## Summary
The grep filter added in #16 breaks `sys.stderr.isatty()` — stderr goes through a pipe, so colors were disabled entirely. Fix: `ARIA_COLOR=1` env var set in check-work.sh, checked in conftest.py.

## Test plan
- [ ] `make test` shows yellow ✗ for deficiencies, green ✓ for passes
- [ ] Cyan phase headers render correctly
- [ ] No raw ANSI codes visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)