### PR TITLE
Fix check-work.sh reporting success when tests fail

### DIFF
--- a/scripts/check-work.sh
+++ b/scripts/check-work.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"


### PR DESCRIPTION
## Summary
- Remove `pipefail` from `check-work.sh` — it clobbers `PIPESTATUS` when combined with `|| true`, causing the script to always show "All objectives verified" even when pytest fails

## Root Cause
`set -o pipefail` + `cmd | grep ... || true` makes `PIPESTATUS` report the result of `true` (0), not pytest's exit code.

## Test plan
- [ ] Run `make test` with incomplete playbook — should show "Deficiencies detected"
- [ ] Run `make test` with complete playbook — should show "All objectives verified"

Fixes starfall-defence-corps/sdc-academy#16